### PR TITLE
Replace uwsgi from conda with pyuwsgi from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ RUN groupadd -r nginx && useradd -r -g nginx nginx
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-# install uWSGI
-RUN conda install -y -c conda-forge uwsgi
-
 # install pypi packages
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -5,7 +5,7 @@ file=/var/run/supervisor%(ENV_ELEPHANT_BATCH_ID)s.sock
 nodaemon=true
 
 [program:uwsgi]
-command=/opt/conda/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini
+command=uwsgi --ini /etc/uwsgi/uwsgi.ini
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/elephant.def
+++ b/elephant.def
@@ -38,9 +38,6 @@ From: pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-    # Install uWSGI
-    conda install -y -c conda-forge uwsgi
-
     # install pypi packages
     python -m pip install -r /src/requirements.txt && rm /src/requirements.txt
     python -m pip install /src/elephant-core && rm -r /src/elephant-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ redis~=5.0.8
 h5py~=3.11.0
 tqdm~=4.66.4
 tensorflow~=2.17.0
+pyuwsgi~=2.0.26


### PR DESCRIPTION
This change is needed for company networks that block access to repo.anaconda.com. Even using conda-forge with mamba still seems to require resolving *.anaconda.com domains, making it unusable for these use cases. The `uwsgi` python package doesn't contain prebuilt wheels, which is why I use `pyuwsgi` here. This also changes the executable path in supervisord.conf.