### PR TITLE
ELEPHANT server v0.6.0 -> v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 # install pypi packages
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN python -m pip install "tifffile<2022.4.22"
 # RUN pip install memory_profiler line_profiler
 # RUN pip install --no-deps stardist==0.8.3 csbdeep==0.7.2 numba==0.56.0 llvmlite==0.39.0 natsort==8.1.0
 


### PR DESCRIPTION
# ELEPHANT server v0.6.1

## Updates

- [fix CTC export](https://github.com/elephant-track/elephant-server/commit/23d4314637867216b03446c695a70f97a91ddddc)