### PR TITLE
[Bug] Fix access to GPU by adding `gpus all` on warmup and launch warmup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,13 @@ stop:
 	fi
 
 warmup:
-	$(eval GPU_ARG:=$(shell \
-	if [ -n "$(ELEPHANT_NVIDIA_GID)" ] && [ -n "$(ELEPHANT_GPU)" ]; then \
-		VAR=$$(echo --gpus '"device=$(ELEPHANT_GPU)"'); \
-	fi;\
-	echo $$VAR))
-	@if [ -n "$(GPU_ARG)" ]; then \
-		$(ELEPHANT_DOCKER) run -it --rm $(GPU_ARG) $(ELEPHANT_IMAGE_NAME) echo "warming up GPU..."; \
-	else \
-		echo "CPU mode..."; \
-	fi
+    $(eval GPU_ARG:=$(shell \
+    if [ -n "$(ELEPHANT_NVIDIA_GID)" ] && [ -n "$(ELEPHANT_GPU)" ]; then \
+        VAR="--gpus device=$(ELEPHANT_GPU)"; \
+    else \
+        VAR="--gpus all"; \
+    fi; \
+    echo $$VAR))
 
 launch: warmup
 	$(ELEPHANT_DOCKER) run -it --rm $(GPU_ARG) --gpus all --shm-size=8g -v $(ELEPHANT_WORKSPACE):/workspace \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ warmup:
 	fi
 
 launch: warmup
-	$(ELEPHANT_DOCKER) run -it --rm $(GPU_ARG) --shm-size=8g -v $(ELEPHANT_WORKSPACE):/workspace \
+	$(ELEPHANT_DOCKER) run -it --rm $(GPU_ARG) --gpus all --shm-size=8g -v $(ELEPHANT_WORKSPACE):/workspace \
 	-p $(ELEPHANT_HTTP_PORT):$(ELEPHANT_HTTP_PORT) \
 	-p $(ELEPHANT_RABBITMQ_NODE_PORT):$(ELEPHANT_RABBITMQ_NODE_PORT) \
 	-p $(ELEPHANT_RABBITMQ_MANAGEMENT_PORT):$(ELEPHANT_RABBITMQ_MANAGEMENT_PORT) \


### PR DESCRIPTION
## What are the changes the user will see?

The GPU access should not fail anymore, regardless of the GPU type the user has.

## Why am I making these changes?

Currently, a lot of GPUs are not detected when trying to access them to use ELEPHANT once the container works.

Example of issue reported : https://forum.image.sc/t/issues-with-gpu-on-local-elephant-server/91424

This pull request should fix this issue.

## What are the changes from a developer perspective?

Changes the `Makefile` :
* Adds `--gpus all` in `launch: warmup`
* Changes the structure of `warmup` to default back to `--gpus all` if no GPU is originally found

## How to test the changes?

Try to install ELEPHANT in 2 contexts :
- on a computer with a GPU that was properly accessible before this fix (example: NVIDIA RTX A6000)
- on a computer with a GPU that was not accessible before this fix (example: NVIDIA RTX 4070)

In both cases, the GPU should be accessed properly.

We only tested on a computer with a GPU that was not accessible before the fix (NVIDIA GeForce RTX 4070 Laptop GPU)